### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,12 +1,15 @@
 name: Scan with Go Linter 🔍
 run-name: ${{ github.actor }} protecting code quality! 🛡️
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
-      - main
-      - develop
-      - 'releases/**'
+     - main
+     - develop
+     - 'releases/**'
 
 jobs:
   golangci:


### PR DESCRIPTION
Potential fix for [https://github.com/Thargelion/tuiter-back/security/code-scanning/2](https://github.com/Thargelion/tuiter-back/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the linting job. This change ensures that the workflow does not inadvertently gain unnecessary write permissions, improving its security posture.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
