### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,6 +7,9 @@ on:
       - develop
       - 'releases/**'
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Thargelion/tuiter-back/security/code-scanning/1](https://github.com/Thargelion/tuiter-back/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function. Based on the tasks performed in the workflow (building, testing, and updating a coverage report), the workflow likely only requires `contents: read` permissions. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `coverage` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
