### PR TITLE
✨ Send author ID to feed

### DIFF
--- a/internal/application/handlers/feed.go
+++ b/internal/application/handlers/feed.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -26,6 +27,8 @@ func NewUserTuitHandler(
 		logger:          logger,
 	}
 }
+
+var errNoToken = errors.New("no user token provided")
 
 type UserTuitHandler struct {
 	useCases        tuitpost.UseCases
@@ -58,7 +61,7 @@ func (l *UserTuitHandler) Search(w http.ResponseWriter, r *http.Request) {
 	token, ok := r.Context().Value(security.TokenMan).(*jwt.Token)
 
 	if !ok {
-		_ = render.Render(w, r, ErrInvalidRequest(err))
+		_ = render.Render(w, r, ErrInvalidRequest(errNoToken))
 
 		return
 	}
@@ -115,7 +118,7 @@ func (l *UserTuitHandler) SearchReplies(writer http.ResponseWriter, request *htt
 	token, ok := request.Context().Value(security.TokenMan).(*jwt.Token)
 
 	if !ok {
-		_ = render.Render(writer, request, ErrInvalidRequest(err))
+		_ = render.Render(writer, request, ErrInvalidRequest(errNoToken))
 
 		return
 	}
@@ -154,7 +157,7 @@ func (u *userPostPayload) Render(_ http.ResponseWriter, _ *http.Request) error {
 }
 
 func newUserPostList(posts []*tuitpost.TuitPost) []render.Renderer {
-	list := []render.Renderer{}
+	var list []render.Renderer
 
 	for _, userPost := range posts {
 		list = append(list, &userPostPayload{userPost})

--- a/internal/domain/tuitpost/model.go
+++ b/internal/domain/tuitpost/model.go
@@ -6,6 +6,7 @@ type TuitPost struct {
 	ID        int    `json:"id"`
 	Message   string `json:"message"`
 	ParentID  int    `json:"parent_id"`
+	AuthorID  int    `json:"author_id"`
 	Author    string `json:"author"`
 	AvatarURL string `json:"avatar_url"`
 	Likes     int    `json:"likes"`

--- a/internal/infrastructure/mysql/feed.go
+++ b/internal/infrastructure/mysql/feed.go
@@ -14,7 +14,7 @@ import (
 const (
 	postsPerPage              = 20
 	projectedPostPartialQuery = `
-	SELECT t.id as id, parent_id, message, u.name as author, u.avatar_url, pl.user_entity_id IS NOT NULL as liked , 
+	SELECT t.id as id, parent_id, message, u.id as author_id, u.name as author, u.avatar_url, pl.user_entity_id IS NOT NULL as liked , 
 	       likes, t.created_at as date 
 		FROM tuits as t
 		    LEFT JOIN (SELECT user_entity_id, tuit_entity_id FROM tuit_likes) pl 


### PR DESCRIPTION
This pull request introduces improvements to error handling and data modeling in the feed handler, as well as updates to the database query and model structure to include the author's ID. The most important changes are grouped below:

**Error Handling Improvements**

* Added a dedicated error variable `errNoToken` to clarify the error message when no user token is provided, and updated error responses in the `Search` and `SearchReplies` methods to use this new error. [[1]](diffhunk://#diff-78d0367e413e1550588884281f42322d804fcc1a566a30e75486888829b428a5R31-R32) [[2]](diffhunk://#diff-78d0367e413e1550588884281f42322d804fcc1a566a30e75486888829b428a5L61-R64) [[3]](diffhunk://#diff-78d0367e413e1550588884281f42322d804fcc1a566a30e75486888829b428a5L118-R121)

**Data Modeling and Query Updates**

* Added a new field `AuthorID` to the `TuitPost` struct to store the author's user ID.
* Updated the SQL query in `feed.go` to select `author_id` from the users table, ensuring this data is available for each post.

**Code Simplification**

* Simplified the initialization of the `list` slice in `newUserPostList` for better readability and performance.